### PR TITLE
Automatische Doku erweitern

### DIFF
--- a/build/defaults.table.xml
+++ b/build/defaults.table.xml
@@ -32,7 +32,7 @@ Dazu muss ein neuer Datensatz angelegt werden.
         <varchar length="100" />
         <desc>Beschreibung</desc>
         <adoc><![CDATA[
-In diesem Feld kann eine nähere Beschreibung für das Konto hinterlegt werden.
+In diesem Feld kann eine nähere Beschreibung für den Datensatz hinterlegt werden.
         ]]></adoc>
     </column>
     <column name="LastAction">
@@ -64,5 +64,15 @@ In diesem Feld wird bei jeder relevanten Änderung der jeweilige Zeitpunkt gespe
         <adoc><![CDATA[
 In diesem Feld wird bei jeder relevanten Änderung durch einen Benutzer dessen Anmeldename gespeichert.
         ]]></adoc>
+    </column>
+     <column name="SecurityToken">
+        <varchar length="10" nullable="true"/>
+        <desc>Tag für die RowLevelSecurity</desc>
+        <adoc><![CDATA[
+In dieser Spalte werden den verschiedenen Einträgen SecurityToken zugesprochen, mithilfe derer man die Einträge nur für bestimmte Nutzer und Nutzergruppen zugänglich machen kann. 
+Ist die Spalte leer, darf jeder sie sehen. 
+Damit auf die RowLevelSecurity geachtet wird muss das RowLevelSecurity-Flag in der xtcasLuUserPrivilegeUserGroup auf 1 gesetzt werden.
+Ansonsten wird die Spalte ignoriert.
+       ]]></adoc>
     </column>
 </table>

--- a/build/form2xml.xsl
+++ b/build/form2xml.xsl
@@ -6,7 +6,7 @@
 
     <!-- Ouput-Deklaration -->
 
-    <xsl:output indent="yes" omit-xml-declaration="no" encoding="UTF-8" xml:space="default" method="xml"/>
+    <xsl:output indent="no" omit-xml-declaration="no" encoding="UTF-8" xml:space="default" method="xml"/>
 
     <!-- Root-Element "form" durchlaufen -->
 

--- a/build/table2adoc.xsl
+++ b/build/table2adoc.xsl
@@ -1,163 +1,211 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<xsl:stylesheet
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-    <!-- Dieses Stylesheet Erstellt aus einer Tabelle ein adoc -->
+	<!-- Dieses Stylesheet Erstellt aus einer Tabelle ein adoc -->
 
-    <!-- Ouput-Deklaration -->
-    <xsl:output indent="no" omit-xml-declaration="yes" encoding="UTF-8" xml:space="default" method="text" />
+	<!-- Ouput-Deklaration -->
+	<xsl:output indent="no" omit-xml-declaration="yes"
+		encoding="UTF-8" xml:space="default" method="text" />
 
-    <!-- Root-Element "table" durchlaufen -->
-    <xsl:template match="/table">
-        <xsl:text>
+	<!-- Root-Element "table" durchlaufen -->
+	<xsl:template match="/table">
+		<xsl:text>
 
 == Tabelle </xsl:text>
-        <xsl:value-of select="./@name" />
-        <xsl:text> (</xsl:text>
-        <xsl:value-of select="./desc" />
-        <xsl:text>)
+		<xsl:value-of select="./@name" />
+		<xsl:text> (</xsl:text>
+		<xsl:value-of select="./desc" />
+		<xsl:text>)
 </xsl:text>
-        <xsl:value-of select="./adoc" />
-        <xsl:text>
+		<xsl:value-of select="./adoc" />
+		<xsl:text>
 
 === Spalten
 
 In der Tabelle sind folgende Spalten definiert.</xsl:text>
-        <xsl:apply-templates select="column" />
-    </xsl:template>
+		<xsl:apply-templates select="column" />
+		<xsl:apply-templates select="values" />
+
+	</xsl:template>
 
 
-    <xsl:template match="column">
-        <xsl:text>
+	<xsl:template match="column">
+		<xsl:text>
 
 ==== </xsl:text>
-        <xsl:value-of select="./@name" />
-        <xsl:text>
+		<xsl:value-of select="./@name" />
+		<xsl:text>
 </xsl:text>
-        <!-- Kurzbezeichnung -->
-        <xsl:apply-templates select="desc" />
+		<!-- Kurzbezeichnung -->
+		<xsl:apply-templates select="desc" />
 
-        <!-- Datentyp angeben -->
-        <xsl:apply-templates select="bigint" />
-        <xsl:apply-templates select="boolean" />
-        <xsl:apply-templates select="datetime" />
-        <xsl:apply-templates select="float" />
-        <xsl:apply-templates select="integer" />
-        <xsl:apply-templates select="money" />
-        <xsl:apply-templates select="varchar" />
+		<!-- Datentyp angeben -->
+		<xsl:apply-templates select="bigint" />
+		<xsl:apply-templates select="boolean" />
+		<xsl:apply-templates select="datetime" />
+		<xsl:apply-templates select="float" />
+		<xsl:apply-templates select="integer" />
+		<xsl:apply-templates select="money" />
+		<xsl:apply-templates select="varchar" />
 
-        <!-- Default angeben -->
-        <xsl:apply-templates select="./@default"></xsl:apply-templates>
+		<!-- Default angeben -->
+		<xsl:apply-templates select="./@default"></xsl:apply-templates>
 
-        <!-- Absatz und lange Beschreibung hinzufügen -->
-        <xsl:text>
+		<!-- Absatz und lange Beschreibung hinzufügen -->
+		<xsl:text>
 
 // tag::column.</xsl:text>
-        <xsl:value-of select="./@name"></xsl:value-of>
-        <xsl:text>[]
+		<xsl:value-of select="./@name"></xsl:value-of>
+		<xsl:text>[]
 </xsl:text>
-        <xsl:if test="./adoc/@default = 'true'">
-            <xsl:text>include::defaults.adoc[tags=column.</xsl:text>
-            <xsl:value-of select="./@name" />
-            <xsl:text>]</xsl:text>
-        </xsl:if>
-        <xsl:if test="not(./adoc/@default = 'true')">
-            <xsl:value-of select="./adoc" />
-        </xsl:if>
-        <xsl:text>
+		<xsl:if test="./adoc/@default = 'true'">
+			<xsl:text>include::defaults.adoc[tags=column.</xsl:text>
+			<xsl:value-of select="./@name" />
+			<xsl:text>]</xsl:text>
+		</xsl:if>
+		<xsl:if test="not(./adoc/@default = 'true')">
+			<xsl:value-of select="./adoc" />
+		</xsl:if>
+		<xsl:text>
 // end::column.</xsl:text>
-        <xsl:value-of select="./@name"></xsl:value-of>
-        <xsl:text>[]
+		<xsl:value-of select="./@name"></xsl:value-of>
+		<xsl:text>[]
 </xsl:text>
-    </xsl:template>
+	</xsl:template>
 
 
-    <xsl:template match="desc">
-        <xsl:text>
+	<xsl:template match="desc">
+		<xsl:text>
 Bezeichnung: </xsl:text>
-        <xsl:value-of select="." />
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:value-of select="." />
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <!-- - - - - - - - - - - - - - - - -->
-    <!-- Datentypen der Spalte -->
-    <!-- - - - - - - - - - - - - - - - -->
-    <xsl:template match="bigint">
-        <xsl:text>
+	<!-- - - - - - - - - - - - - - - - -->
+	<!-- Datentypen der Spalte -->
+	<!-- - - - - - - - - - - - - - - - -->
+	<xsl:template match="bigint">
+		<xsl:text>
 Datentyp: bigint</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="boolean">
-        <xsl:text>
+	<xsl:template match="boolean">
+		<xsl:text>
 Datentyp: bit</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="datetime">
-        <xsl:text>
+	<xsl:template match="datetime">
+		<xsl:text>
 Datentyp: datetime</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="float">
-        <xsl:text>
+	<xsl:template match="float">
+		<xsl:text>
 Datentyp: float</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="integer">
-        <xsl:text>
+	<xsl:template match="integer">
+		<xsl:text>
 Datentyp: integer</xsl:text>
-        <xsl:if test="@identity">
-            <xsl:text> (identity)</xsl:text>
-        </xsl:if>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@identity">
+			<xsl:text> (identity)</xsl:text>
+		</xsl:if>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="money">
-        <xsl:text>
+	<xsl:template match="money">
+		<xsl:text>
 Datentyp: money</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <xsl:template match="varchar">
-        <xsl:text>
+	<xsl:template match="varchar">
+		<xsl:text>
 Datentyp: nvarchar(</xsl:text>
-        <xsl:value-of select="./@length" />
-        <xsl:text>)</xsl:text>
-        <xsl:if test="@nullable = 'false'">
-            <xsl:text> not null</xsl:text>
-        </xsl:if>
-        <xsl:text> +</xsl:text>
-    </xsl:template>
+		<xsl:value-of select="./@length" />
+		<xsl:text>)</xsl:text>
+		<xsl:if test="@nullable = 'false'">
+			<xsl:text> not null</xsl:text>
+		</xsl:if>
+		<xsl:text> +</xsl:text>
+	</xsl:template>
 
-    <!-- - - - - - - - - - - - - - - - -->
-    <!-- Defaultwert anzeigen -->
-    <!-- - - - - - - - - - - - - - - - -->
-    <xsl:template match="column/@default">
-        <xsl:text>
+	<!-- - - - - - - - - - - - - - - - -->
+	<!-- Defaultwert anzeigen -->
+	<!-- - - - - - - - - - - - - - - - -->
+	<xsl:template match="column/@default">
+		<xsl:text>
 Default: `</xsl:text>
-        <xsl:value-of select="." />
-        <xsl:text>` +</xsl:text>
-    </xsl:template>
+		<xsl:value-of select="." />
+		<xsl:text>` +</xsl:text>
+	</xsl:template>
+
+	<!-- - - - - - - - - - - - - - - - -->
+	<!-- Automatisch generierte Zeilen als Tabelle anzeigen -->
+	<!-- - - - - - - - - - - - - - - - -->
+	<xsl:template match="values">
+		<xsl:text>
+
+=== Zeilen
+
+Folgende Zeilen werden automatisch angelegt:
+
+[options="header"]
+|======
+</xsl:text>
+
+		<xsl:apply-templates select="column/@refid" />
+
+		<xsl:apply-templates select="row" />
+
+		<xsl:text>
+|======
+</xsl:text>
+
+	</xsl:template>
+
+	<xsl:template match="column/@refid">
+		<xsl:text>| </xsl:text>
+		<xsl:value-of select="." />
+		<xsl:text> </xsl:text>
+	</xsl:template>
+
+
+	<xsl:template match="row">
+		<xsl:text> <xsl:apply-templates select="value" /> 
+</xsl:text>
+	</xsl:template>
+
+
+	<xsl:template match="value">
+		<xsl:text>| </xsl:text>
+		<xsl:value-of select="." />
+		<xsl:text> </xsl:text>
+	</xsl:template>
 
 
 </xsl:stylesheet>

--- a/build/table2adoc.xsl
+++ b/build/table2adoc.xsl
@@ -177,15 +177,11 @@ Folgende Zeilen werden automatisch angelegt:
 [options="header"]
 |======
 </xsl:text>
-
 		<xsl:apply-templates select="column/@refid" />
-
 		<xsl:apply-templates select="row" />
-
 		<xsl:text>
 |======
 </xsl:text>
-
 	</xsl:template>
 
 	<xsl:template match="column/@refid">
@@ -194,18 +190,15 @@ Folgende Zeilen werden automatisch angelegt:
 		<xsl:text> </xsl:text>
 	</xsl:template>
 
-
 	<xsl:template match="row">
 		<xsl:text> <xsl:apply-templates select="value" /> 
 </xsl:text>
 	</xsl:template>
-
 
 	<xsl:template match="value">
 		<xsl:text>| </xsl:text>
 		<xsl:value-of select="." />
 		<xsl:text> </xsl:text>
 	</xsl:template>
-
 
 </xsl:stylesheet>

--- a/build/table2xml.xsl
+++ b/build/table2xml.xsl
@@ -5,7 +5,7 @@
 
     <!-- Ouput-Deklaration -->
 
-    <xsl:output indent="yes" omit-xml-declaration="no" encoding="UTF-8" xml:space="default" method="xml"/>
+    <xsl:output indent="no" omit-xml-declaration="no" encoding="UTF-8" xml:space="default" method="xml"/>
 
     <!-- Root-Element "form" durchlaufen -->
 


### PR DESCRIPTION
- Defaults-Vorlage um Spalte SecurityToken erweitern
- Leerzeilen in generierten Forms und Tables vermeiden
- Im Schema definierte Zeilen automatisch dokumentieren. Sind keine Zeilen definiert kommt der Abschnitt in der Doku auch nicht vor. Beispiel für [xtsamVehicleType](https://github.com/minova-afis/aero.minova.sam.scharr/blob/main/app/src/main/app/tables/xtsamVehicleType.table.xml):

```
=== Zeilen

Folgende Zeilen werden automatisch angelegt:

[options="header"]
|======
| KeyLong | KeyText | Description   
| 1 | Tankwagen |    
| 2 | Anhänger |    
| 3 | Zugmaschine |    
| 4 | Auflieger |    
| 5 | PKW |  
|======
```

<img width="504" alt="Bildschirmfoto 2022-07-18 um 15 52 11" src="https://user-images.githubusercontent.com/77741125/179526617-abc5f965-8edb-4686-95dc-867a73b6ee37.png">
